### PR TITLE
Fix: Revert appointment lookup to 60 days past + 60 days future

### DIFF
--- a/src/services/bookingService.js
+++ b/src/services/bookingService.js
@@ -435,11 +435,22 @@ export async function cancelBooking(bookingId) {
 
 /**
  * Lookup customer bookings
+ * Returns appointments from 60 days past to 60 days future
  */
 export async function lookupCustomerBookings(customerId) {
   const now = new Date();
+  
+  // 60 days in the past
+  const past = new Date();
+  past.setDate(past.getDate() - 60);
+  
+  // 60 days in the future
   const future = new Date();
-  future.setDate(future.getDate() + 30);
+  future.setDate(future.getDate() + 60);
+  
+  console.log(`🔍 Looking up bookings for customer ${customerId}`);
+  console.log(`   Range: ${past.toISOString()} to ${future.toISOString()}`);
+  console.log(`   (60 days past to 60 days future)`);
   
   const bookingsResponse = await squareClient.bookingsApi.listBookings(
     undefined,
@@ -447,7 +458,7 @@ export async function lookupCustomerBookings(customerId) {
     customerId,
     undefined,
     LOCATION_ID,
-    now.toISOString(),
+    past.toISOString(),
     future.toISOString()
   );
   


### PR DESCRIPTION
## Problem
The `lookupCustomerBookings` function was only looking **30 days into the future** and **0 days into the past**. 

This meant:
- Customers couldn't see their recent past appointments
- The lookback window was too short

## Solution
Changed the `lookupCustomerBookings` function in `src/services/bookingService.js` to:
- Look back **60 days** in the past
- Look forward **60 days** in the future

## Changes Made
**File:** `src/services/bookingService.js`

**Before:**
```javascript
const now = new Date();
const future = new Date();
future.setDate(future.getDate() + 30);
```

**After:**
```javascript
const now = new Date();

// 60 days in the past
const past = new Date();
past.setDate(past.getDate() - 60);

// 60 days in the future
const future = new Date();
future.setDate(future.getDate() + 60);
```

## Testing
After merging and deploying, the appointment lookup will retrieve:
✅ Appointments from 60 days ago
✅ Appointments up to 60 days in the future

## Impact
- Customers can now see their recent past appointments
- Proper appointment history is available for the AI receptionist
- No breaking changes - just an expanded date range